### PR TITLE
[DEV] common modal 개발

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,7 +68,8 @@ const NavBar = () => {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="kr" className={`${poppins.variable} ${pretendard.variable}`}>
-            <body className="relative h-screen max-h-screen min-h-screen bg-theme-background font-kor text-theme-font">
+            <body className="relative h-screen max-h-screen bg-theme-background font-kor text-theme-font">
+                <div id="modal-root" />
                 <NavBar />
                 <main className="mx-auto h-full w-2/3">{children}</main>
             </body>

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -1,0 +1,2 @@
+export * from './modal'
+export * from './useModal'

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const blurLevel = {
+    none: 'backdrop-blur-none',
+    sm: 'backdrop-blur-sm',
+    md: 'backdrop-blur-md',
+    lg: 'backdrop-blur-lg',
+    xl: 'backdrop-blur-xl',
+    '2xl': 'backdrop-blur-2xl',
+    '3xl': 'backdrop-blur-3xl',
+} as const
+type BlurLevel = keyof typeof blurLevel
+type TransitionDuration =
+    | 'duration-50'
+    | 'duration-75'
+    | 'duration-100'
+    | 'duration-150'
+    | 'duration-200'
+    | 'duration-300'
+    | 'duration-500'
+    | 'duration-700'
+    | 'duration-1000'
+
+interface ModalViewProps {
+    open: boolean
+    onOutsideClick?: () => void
+    blur?: BlurLevel
+    transitionDuration?: TransitionDuration
+    modalCloseClassName?: string
+    modalOpenClassName?: string
+}
+export const ModalView = ({
+    children,
+    open,
+    blur = 'none',
+    modalCloseClassName,
+    modalOpenClassName,
+    transitionDuration,
+    onOutsideClick,
+}: React.PropsWithChildren<ModalViewProps>) => {
+    const handleOutsideClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+        const isModalContentClicked = e.target !== e.currentTarget
+        if (isModalContentClicked) return
+
+        onOutsideClick?.()
+    }
+    return (
+        <div
+            className={`fixed left-0 top-0 h-full w-full overflow-hidden bg-black/5 transition ${transitionDuration} ${
+                blurLevel[blur]
+            } ${open ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'}`}
+        >
+            <div
+                className={`flex h-full w-full transform-gpu items-center justify-center transition ${transitionDuration} ${
+                    open ? `opacity-100 ${modalOpenClassName}` : `opacity-0 ${modalCloseClassName}`
+                }`}
+                onClick={handleOutsideClick}
+            >
+                {children}
+            </div>
+        </div>
+    )
+}
+
+export const Modal = (modalViewProps: React.PropsWithChildren<ModalViewProps>) => {
+    const [isClient, setIsClient] = useState(false)
+    useEffect(() => {
+        setIsClient(true)
+    }, [])
+
+    return (
+        <>
+            {isClient ? (
+                createPortal(<ModalView {...modalViewProps} />, document.getElementById('modal-root') as HTMLDivElement)
+            ) : (
+                <div />
+            )}
+        </>
+    )
+}

--- a/src/components/modal/useModal.ts
+++ b/src/components/modal/useModal.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+/**
+ * Modal state managing hook
+ */
+export const useModal = () => {
+    const [open, setOpen] = useState(false)
+
+    const modalAction = useMemo(() => {
+        return {
+            open: () => setOpen(true),
+            close: () => setOpen(false),
+            toggle: () => setOpen((prev) => !prev),
+        }
+    }, [])
+
+    return {
+        action: modalAction,
+        open,
+    }
+}


### PR DESCRIPTION
## Summary
공용 modal component를 개발했습니다.

## Description
- `layout.tsx`의 `<div id="modal-root" />`에 modal을 렌더링합니다.
- modal 생성시 상단 nav-bar를 제외한 나머지 요소는 blur 처리 됩니다.
- Modal 컴포넌트와 useModal modal 상태관리용 훅을 함께 사용합니다.
    1. Modal 컴포넌트: modal view입니다. `children`에 컴포넌트를 넣고 렌더링합니다.
    2. useModal 훅: modal 상태관리 훅입니다. 반드시 Modal 컴포넌트에 open prop을 주입합니다.

## Example

1. 우선 `import { Modal, useModal } from '~/components/modal'`로 컴포넌트를 불러옵니다.
2. 다음과 같은 prop을 사용하여 modal의 움직임과 background blur level을 제어합니다.
```bash
blur="2xl"
onOutsideClick={action.close}
transitionDuration="duration-300"
modalOpenClassName="translate-x-0 scale-100"
modalCloseClassName="translate-x-1/2 scale-75"
```
3. 컴포넌트를 작성합니다.
```tsx
// use client notation 을 반드시 달아야 합니다.
'use client'

import { Modal, useModal } from '~/components/modal'

export const TestModal = () => {
    // modal 상태관리용 훅을 불러옵니다.
    const { action, open } = useModal()

    return (
        <>
            <button onClick={action.open} className="rounded bg-primary-teal p-2 text-black">
                모달 열기 버튼
            </button>

            <Modal
                open={open}
                blur="2xl"
                onOutsideClick={action.close}
                transitionDuration="duration-300"
                modalOpenClassName="translate-x-0 scale-100"
                modalCloseClassName="translate-x-1/2 scale-75"
            >
                <div className="flex h-fit w-4/5 flex-col justify-between gap-4 rounded-md bg-neutral-950 p-4 md:w-1/2">
                    <h1 className="text-2xl font-bold">Modal 콘텐츠</h1>
                    Modal에 children을 넣으면 rendering 됩니다
                    <button onClick={action.close} className="rounded bg-neutral-900 p-2">
                        닫기
                    </button>
                </div>
            </Modal>
        </>
    )
}
```
4. 렌더링 결과
![modal](https://github.com/GDSC-CAU/GDSC-SPACE/assets/53421296/26795cd2-31ff-49a9-b045-7fcf373abc23)


