### PR TITLE
[DEV] add nav btn

### DIFF
--- a/src/app/_components/index.ts
+++ b/src/app/_components/index.ts
@@ -1,0 +1,1 @@
+export * from './nav'

--- a/src/app/_components/nav/index.tsx
+++ b/src/app/_components/nav/index.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import { Gdsc } from '~/components/icons'
+import { Link$, type LinkPath } from '~/components/index'
+
+interface NavButtonProps<Props extends { type: 'link' | 'scroll' }> {
+    type: 'link' | 'scroll'
+    href: Props['type'] extends 'link' ? (Props['type'] extends 'scroll' ? never : LinkPath) : `${LinkPath}#${string}`
+    children: React.ReactNode
+    disableUnderline?: boolean
+}
+const NavButton = <Props extends NavButtonProps<Props>>({ type, href, children, disableUnderline = false }: Props) => {
+    const isLink = type === 'link'
+
+    const TargetLink = isLink ? Link$ : Link
+    const shouldScrollToTop: boolean = isLink ? true : false
+
+    return (
+        <TargetLink
+            className="group select-none text-base md:text-sm"
+            href={href as LinkPath}
+            scroll={shouldScrollToTop}
+        >
+            <p className="font-eng font-normal transition-opacity group-hover:opacity-90">{children}</p>
+            {!disableUnderline && (
+                <div className="h-[0.75px] w-full scale-x-0 rounded bg-theme-font transition-all duration-200 group-hover:scale-x-100 group-hover:opacity-90" />
+            )}
+        </TargetLink>
+    )
+}
+
+interface NavBarProps {
+    iconSize?: number
+}
+export const NavBar = ({ iconSize = 55 }: NavBarProps) => {
+    return (
+        <nav className="sticky top-[0rem] z-50 flex h-fit flex-row items-center justify-center bg-theme-background/5 py-4 backdrop-blur-2xl md:gap-16">
+            <NavButton type="link" href="/" disableUnderline>
+                <Gdsc width={iconSize} height={iconSize} className="scale-75 md:scale-100" />
+            </NavButton>
+
+            <NavButton type="scroll" href="/#about">
+                About us
+            </NavButton>
+            <NavButton type="scroll" href="/#projects">
+                Projects
+            </NavButton>
+
+            <NavButton type="link" href="/blog">
+                Blog
+            </NavButton>
+            <NavButton type="link" href="/events">
+                Events
+            </NavButton>
+            <NavButton type="link" href="/members">
+                Members
+            </NavButton>
+        </nav>
+    )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import '../styles/tailwind.css'
 import { Poppins } from 'next/font/google'
 import localFont from 'next/font/local'
-import { Gdsc } from '~/components/icons'
-import { Link$, type LinkPath } from '../components'
+import { NavBar } from './_components'
 
 const pretendard = localFont({
     src: [
@@ -31,46 +30,12 @@ export const metadata = {
     description: 'welcome to space',
 }
 
-const NavButton = ({
-    href,
-    children,
-    disableUnderline = false,
-}: {
-    href: LinkPath
-    children: React.ReactNode
-    disableUnderline?: boolean
-}) => {
-    return (
-        <Link$ className="group select-none text-xs md:text-sm" href={href}>
-            <p className="transition-opacity group-hover:opacity-90">{children}</p>
-            {!disableUnderline && (
-                <div className="h-[0.75px] w-full scale-x-0 rounded bg-gray-300 transition-all duration-200 group-hover:scale-x-100 group-hover:opacity-90" />
-            )}
-        </Link$>
-    )
-}
-
-const NavBar = () => {
-    const iconSize = 55
-
-    return (
-        <nav className="sticky top-0 flex h-14 flex-row items-center justify-center gap-10 bg-neutral-600/5 py-4 backdrop-blur-2xl md:h-20 md:gap-28">
-            <NavButton href="/" disableUnderline>
-                <Gdsc width={iconSize} height={iconSize} className="scale-75 md:scale-100" />
-            </NavButton>
-            <NavButton href="/blog">Blog</NavButton>
-            <NavButton href="/events">Events</NavButton>
-            <NavButton href="/members">Members</NavButton>
-        </nav>
-    )
-}
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="kr" className={`${poppins.variable} ${pretendard.variable}`}>
-            <body className="relative h-screen max-h-screen bg-theme-background font-kor text-theme-font">
-                <div id="modal-root" />
+            <body className="relative h-fit min-h-screen bg-theme-background font-kor text-theme-font">
                 <NavBar />
+                <div id="modal-root" />
                 <main className="mx-auto h-full w-2/3">{children}</main>
             </body>
         </html>

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -3,7 +3,7 @@ import Link, { type LinkProps } from 'next/link'
 /**
  * Project link path
  */
-export type LinkPath = '/' | '/members' | '/blog' | '/events'
+export type LinkPath = '/' | '/members' | '/blog' | '/projects' | '/events'
 
 interface Link$Props extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps>, LinkProps {
     href: LinkPath


### PR DESCRIPTION
## Summary
scroll nav button을 추가했습니다.

## Description
- Next.js Link 컴포넌트로 projects, about us로 이동하는 버튼을 추가했습니다.
- `type="scroll"`을 추가하고 스크롤 타겟 요소의 `id`로 `href`속성을 적습니다.
```tsx
const Some = () => {
   return  (
       <NavButton type="scroll" href="/#about">
            About us
       </NavButton>
   )
}
```

```tsx
const Page = () => {
    return (
        <div>
            <h1 id="about">여기로 스크롤 됩니다.</h1>
        <div/>
    )
}
```