### PR TITLE
[DEV] API 라우팅 구성

### DIFF
--- a/src/app/api/blog/getDetail/[type]/[id]/route.ts
+++ b/src/app/api/blog/getDetail/[type]/[id]/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest, { params }: { params: { id: string; type: string } }) {
+    return NextResponse.json({ date: 'Blog Detail', id: params.id, type: params.type }, { status: 200 })
+}

--- a/src/app/api/blog/getList/[type]/route.ts
+++ b/src/app/api/blog/getList/[type]/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest, { params }: { params: { type: string } }) {
+    return NextResponse.json({ date: 'Blog List', type: params.type }, { status: 200 })
+}

--- a/src/app/api/event/getDetail/[id]/route.ts
+++ b/src/app/api/event/getDetail/[id]/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+    return NextResponse.json({ date: 'Event Detail', id: params.id }, { status: 200 })
+}

--- a/src/app/api/event/getList/route.ts
+++ b/src/app/api/event/getList/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+    return NextResponse.json({ date: 'Event List' }, { status: 200 })
+}

--- a/src/app/api/main/getProjects/route.ts
+++ b/src/app/api/main/getProjects/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+    return NextResponse.json({ date: 'Main Projects' }, { status: 200 })
+}

--- a/src/app/api/main/getTimelines/route.ts
+++ b/src/app/api/main/getTimelines/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+    return NextResponse.json({ date: 'Main Timelines' }, { status: 200 })
+}

--- a/src/app/api/member/getList/[year]/route.ts
+++ b/src/app/api/member/getList/[year]/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest, { params }: { params: { year: string } }) {
+    return NextResponse.json({ date: 'Member List', year: params.year }, { status: 200 })
+}


### PR DESCRIPTION
## Summary
API 구현을 위한 라우팅을 구성하였습니다.

## Description
- 본격적인 API 개발 및 외부API 연동에 앞서, 본 프로젝트에서 필요로 하는 각 API에 대한 라우팅을 구성하였습니다.
- `/api/`를 경로의 Prefix로 하여 접근할 수 있습니다.
- Blog 관련 API는 `getList`와 `getDetail`로 구성되며, 각각 타입에 대한 전체 글 목록을 반환하는 함수와, 특정 글에 대한 상세 항목을 반환하는 함수입니다.
- Event 관련 API는 마찬가지로 `getList`와 `getDetail`로 구성되며, Blog API와 유사합니다.
- Member 관련 API는 전체 멤버 목록을 반환하는 `getList`로 구성되어 있습니다.
- Main에서는 타임라인 정보와 대표 프로젝트 목록을 반환하는 함수인 `getTimelines`와 `getProjects`로 구성됩니다.
- 각 함수는 현재 `HTTP GET`으로 정의되어있으며, 인자를 올바르게 입력한 경우에만 동작하도록 구성해두었습니다.