### PR TITLE
[FIX] NavButton 링크 Type 이슈 해결

### DIFF
--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -3,7 +3,7 @@ import Link, { type LinkProps } from 'next/link'
 /**
  * Project link path
  */
-export type LinkPath = '/' | `/members` | '/blog' | '/events'
+export type LinkPath = '/' | `/members` | '/blog' | `/blog/${string}` | '/events' | `/events/${string}`
 
 interface Link$Props extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps>, LinkProps {
     href: LinkPath

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -3,7 +3,7 @@ import Link, { type LinkProps } from 'next/link'
 /**
  * Project link path
  */
-export type LinkPath = '/' | `/members/${string}` | '/blog' | '/events'
+export type LinkPath = '/' | `/members` | '/blog' | '/events'
 
 interface Link$Props extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps>, LinkProps {
     href: LinkPath


### PR DESCRIPTION
## Summary
NavButton에서 발생하던 TypeError를 해결하였습니다.

## Description
- NavButton의 `/members` Link 항목에서 TypeError가 발생하던 것을 해결하였습니다.
- `Link.tsx` 내의 `LinkPath` Type 정의에서, `/members`가 아닌 `/members/${string}`으로 되어있던 것을 수정하였습니다.
- 추후 Blog 및 Event의 Link 구성을 위해, 하위 링크를 `/${string}`으로 갖는 두개 항목을 추가하였습니다.