### PR TITLE
[DEV] API Dummy 데이터 Response 구성

### DIFF
--- a/src/app/api/blog/getDetail/[type]/[id]/route.ts
+++ b/src/app/api/blog/getDetail/[type]/[id]/route.ts
@@ -1,5 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { API_BLOG_DETAIL, API_RESPONSE } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest, { params }: { params: { id: string; type: string } }) {
-    return NextResponse.json({ date: 'Blog Detail', id: params.id, type: params.type }, { status: 200 })
+    const dummyBlogDetail: API_BLOG_DETAIL = {
+        BLOG_AUTHOR: 'Dev. LR',
+        BLOG_CONTENT: [{ CONTENT_TYPE: 'text', CONTENT_DATA: 'Test Content' }],
+        BLOG_DATE: '2023. 08. 23.',
+        BLOG_ID: params.id,
+        BLOG_TAG: ['Application', 'Flutter'],
+        BLOG_TITLE: `${params.type} ${params.id}`,
+    }
+
+    const apiResultSuccess: API_RESPONSE = {
+        RESULT_CODE: 200,
+        RESULT_MSG: 'Success',
+        RESULT_DATA: dummyBlogDetail,
+    }
+
+    if (params.type !== 'Design' && params.type !== 'Development' && params.type !== 'Project') {
+        const apiResultError: API_RESPONSE = {
+            RESULT_CODE: 100,
+            RESULT_MSG: 'Blog Type Error',
+            RESULT_DATA: undefined,
+        }
+
+        return NextResponse.json(apiResultError, { status: 200 })
+    }
+
+    return NextResponse.json(apiResultSuccess, { status: 200 })
 }

--- a/src/app/api/blog/getDetail/[type]/[id]/route.ts
+++ b/src/app/api/blog/getDetail/[type]/[id]/route.ts
@@ -2,6 +2,16 @@ import { NextRequest, NextResponse } from 'next/server'
 import { API_BLOG_DETAIL, API_RESPONSE } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest, { params }: { params: { id: string; type: string } }) {
+    if (params.type !== 'Design' && params.type !== 'Development' && params.type !== 'Project') {
+        const apiResultError: API_RESPONSE = {
+            RESULT_CODE: 100,
+            RESULT_MSG: 'Blog Type Error',
+            RESULT_DATA: undefined,
+        }
+
+        return NextResponse.json(apiResultError, { status: 200 })
+    }
+
     const dummyBlogDetail: API_BLOG_DETAIL = {
         BLOG_AUTHOR: 'Dev. LR',
         BLOG_CONTENT: [{ CONTENT_TYPE: 'text', CONTENT_DATA: 'Test Content' }],
@@ -15,16 +25,6 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
         RESULT_CODE: 200,
         RESULT_MSG: 'Success',
         RESULT_DATA: dummyBlogDetail,
-    }
-
-    if (params.type !== 'Design' && params.type !== 'Development' && params.type !== 'Project') {
-        const apiResultError: API_RESPONSE = {
-            RESULT_CODE: 100,
-            RESULT_MSG: 'Blog Type Error',
-            RESULT_DATA: undefined,
-        }
-
-        return NextResponse.json(apiResultError, { status: 200 })
     }
 
     return NextResponse.json(apiResultSuccess, { status: 200 })

--- a/src/app/api/blog/getDetail/[type]/[id]/route.ts
+++ b/src/app/api/blog/getDetail/[type]/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { API_BLOG_DETAIL, API_RESPONSE } from '~/src/interfaces/common'
+import { API_BLOG_DETAIL, API_RESPONSE, BLOG_POST_PARAMS } from '~/src/interfaces'
 
-export async function GET(request: NextRequest, { params }: { params: { id: string; type: string } }) {
+export async function GET(request: NextRequest, { params }: BLOG_POST_PARAMS) {
     if (params.type !== 'Design' && params.type !== 'Development' && params.type !== 'Project') {
         const apiResultError: API_RESPONSE = {
             RESULT_CODE: 100,

--- a/src/app/api/blog/getList/[type]/route.ts
+++ b/src/app/api/blog/getList/[type]/route.ts
@@ -1,5 +1,39 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { API_BLOG_LIST, API_RESPONSE } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest, { params }: { params: { type: string } }) {
-    return NextResponse.json({ date: 'Blog List', type: params.type }, { status: 200 })
+    if (params.type !== 'Design' && params.type !== 'Development' && params.type !== 'Project') {
+        const apiResultError: API_RESPONSE = {
+            RESULT_CODE: 100,
+            RESULT_MSG: 'Blog Type Error',
+            RESULT_DATA: undefined,
+        }
+
+        return NextResponse.json(apiResultError, { status: 200 })
+    }
+
+    const dummyBlogList: API_BLOG_LIST = {
+        BLOG_CNT: 10,
+        BLOG_LIST: [],
+    }
+
+    for (let i = 0; i < 10; i++) {
+        dummyBlogList.BLOG_LIST.push({
+            BLOG_AUTHOR: 'Dev. LR',
+            BLOG_DATE: '2023. 08. 23.',
+            BLOG_DESCRIPTION: `This is Test Posting of ${params.type}`,
+            BLOG_ID: `${i}`,
+            BLOG_TAG: ['Application', 'Flutter'],
+            BLOG_THUMBNAIL: 'https://cdn.pixabay.com/photo/2023/08/11/18/35/flowers-8184126_1280.jpg',
+            BLOG_TITLE: `${params.type} ${i}`,
+        })
+    }
+
+    const apiResultSuccess: API_RESPONSE = {
+        RESULT_CODE: 200,
+        RESULT_MSG: 'Success',
+        RESULT_DATA: dummyBlogList,
+    }
+
+    return NextResponse.json(apiResultSuccess, { status: 200 })
 }

--- a/src/app/api/blog/getList/[type]/route.ts
+++ b/src/app/api/blog/getList/[type]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { API_BLOG_LIST, API_RESPONSE } from '~/src/interfaces/common'
+import { API_BLOG_LIST, API_RESPONSE, BLOG_TYPE_PARAMS } from '~/src/interfaces'
 
-export async function GET(request: NextRequest, { params }: { params: { type: string } }) {
+export async function GET(request: NextRequest, { params }: BLOG_TYPE_PARAMS) {
     if (params.type !== 'Design' && params.type !== 'Development' && params.type !== 'Project') {
         const apiResultError: API_RESPONSE = {
             RESULT_CODE: 100,

--- a/src/app/api/event/getDetail/[id]/route.ts
+++ b/src/app/api/event/getDetail/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { API_EVENT_DETAIL, API_RESPONSE } from '~/src/interfaces/common'
+import { API_EVENT_DETAIL, API_RESPONSE, EVENT_PAGE_PARAMS } from '~/src/interfaces'
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(request: NextRequest, { params }: EVENT_PAGE_PARAMS) {
     const dummyEventDetail: API_EVENT_DETAIL = {
         EVENT_BANNER: 'https://cdn.pixabay.com/photo/2023/08/11/18/35/flowers-8184126_1280.jpg',
         EVENT_CONTENT: [{ CONTENT_TYPE: 'text', CONTENT_DATA: 'Test Content' }],

--- a/src/app/api/event/getDetail/[id]/route.ts
+++ b/src/app/api/event/getDetail/[id]/route.ts
@@ -1,5 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { API_EVENT_DETAIL, API_RESPONSE } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
-    return NextResponse.json({ date: 'Event Detail', id: params.id }, { status: 200 })
+    const dummyEventDetail: API_EVENT_DETAIL = {
+        EVENT_BANNER: 'https://cdn.pixabay.com/photo/2023/08/11/18/35/flowers-8184126_1280.jpg',
+        EVENT_CONTENT: [{ CONTENT_TYPE: 'text', CONTENT_DATA: 'Test Content' }],
+        EVENT_DATE: '2023. 08. 23.',
+        EVENT_ID: params.id,
+        EVENT_LINK: 'https://gdsc-cau.github.io',
+        EVENT_TITLE: `Event ${params.id}`,
+    }
+
+    const apiResult: API_RESPONSE = {
+        RESULT_CODE: 200,
+        RESULT_MSG: 'Success',
+        RESULT_DATA: dummyEventDetail,
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
 }

--- a/src/app/api/event/getList/route.ts
+++ b/src/app/api/event/getList/route.ts
@@ -1,5 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { API_EVENT_LIST, API_RESPONSE } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest) {
-    return NextResponse.json({ date: 'Event List' }, { status: 200 })
+    const dummyEventList: API_EVENT_LIST = {
+        EVENT_CNT: 10,
+        EVENT_LIST: [],
+    }
+
+    for (let i = 0; i < 10; i++) {
+        dummyEventList.EVENT_LIST.push({
+            EVENT_DATE: '2023. 08. 23.',
+            EVENT_DESCRIPTION: `This is Test Event ${i}`,
+            EVENT_ID: `${i}`,
+            EVENT_THUMBNAIL: 'https://cdn.pixabay.com/photo/2023/08/11/18/35/flowers-8184126_1280.jpg',
+            EVENT_TITLE: `Event ${i}`,
+            EVENT_TYPE: 'Association',
+        })
+    }
+
+    const apiResult: API_RESPONSE = {
+        RESULT_CODE: 200,
+        RESULT_MSG: 'Success',
+        RESULT_DATA: dummyEventList,
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
 }

--- a/src/app/api/main/getProjects/route.ts
+++ b/src/app/api/main/getProjects/route.ts
@@ -1,5 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { API_MAIN_PROJECTS, API_RESPONSE, MAIN_PROJECT_DATA } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest) {
-    return NextResponse.json({ date: 'Main Projects' }, { status: 200 })
+    const dummyProjectData: MAIN_PROJECT_DATA = {
+        PROJECT_DESCRIPTION:
+            "This is a Solution for the people who don't know what actions could be taken toreduce green house effect.This is an education game. By playing this game, the players are informedwhat could be done in real world to decrease the green house effect andwhat contributes to the global warming and green house effect.",
+        PROJECT_ID: 'PROJECT_ID',
+        PROJECT_IMAGE: 'https://cdn.pixabay.com/photo/2023/08/11/18/35/flowers-8184126_1280.jpg',
+        PROJECT_IMAGE_SUB: 'https://cdn.pixabay.com/photo/2023/08/05/15/15/waves-8171279_1280.jpg',
+        PROJECT_SUBTITLE: ': No more Lonely Death',
+        PROJECT_TITLE: 'Wiro',
+    }
+
+    const dummyProjectList: API_MAIN_PROJECTS = {
+        MAIN_PROJECT_CNT: 4,
+        MAIN_PROJECT_LIST: [],
+    }
+
+    for (let i = 0; i < 4; i++) {
+        dummyProjectList.MAIN_PROJECT_LIST.push(dummyProjectData)
+    }
+
+    const apiResult: API_RESPONSE = {
+        RESULT_CODE: 200,
+        RESULT_MSG: 'Success',
+        RESULT_DATA: dummyProjectList,
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
 }

--- a/src/app/api/main/getTimelines/route.ts
+++ b/src/app/api/main/getTimelines/route.ts
@@ -1,5 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { API_MAIN_TIMELINES, API_RESPONSE, MAIN_TIMELINE_DATA } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest) {
-    return NextResponse.json({ date: 'Main Timelines' }, { status: 200 })
+    const dummyTimelineData: MAIN_TIMELINE_DATA = {
+        TIMELINE_CARD_TITLE: 'TIMELINE CARD TITLE',
+        TIMELINE_DATE: '2023. 8.',
+        TIMELINE_DESCRIPTION: 'This is Test Timeline Item!',
+        TIMELINE_TITLE: 'TEST TIMELINE TITLE',
+    }
+
+    const dummyTimelineList: API_MAIN_TIMELINES = {
+        MAIN_TIMELINE_CNT: 6,
+        MAIN_TIMELINE_LIST: [],
+    }
+
+    for (let i = 0; i < 6; i++) {
+        dummyTimelineList.MAIN_TIMELINE_LIST.push(dummyTimelineData)
+    }
+
+    const apiResult: API_RESPONSE = {
+        RESULT_CODE: 200,
+        RESULT_MSG: 'Success',
+        RESULT_DATA: dummyTimelineList,
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
 }

--- a/src/app/api/member/getList/[year]/route.ts
+++ b/src/app/api/member/getList/[year]/route.ts
@@ -1,5 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { API_MAIN_MEMBERS, API_MEMBER_LIST, API_RESPONSE, MEMBER_DATA } from '~/src/interfaces/common'
 
 export async function GET(request: NextRequest, { params }: { params: { year: string } }) {
-    return NextResponse.json({ date: 'Member List', year: params.year }, { status: 200 })
+    const dummyMemberData: MEMBER_DATA = {
+        MEMBER_COMMENT: '안녕하세요, GDSC 3기 리드 유용민입니다. 잘 부탁드립니다:)',
+        MEMBER_EMAIL: 'yymin1022@gmail.com',
+        MEMBER_GENDER: 'Male',
+        MEMBER_INSTAGRAM: 'instagram',
+        MEMBER_IMAGE: '',
+        MEMBER_LINK_BEHANCE: '',
+        MEMBER_LINK_GITHUB: 'github.com/yymin1022',
+        MEMBER_NAME: `유용민`,
+        MEMBER_NICKNAME: 'DEV.LR',
+        MEMBER_POSITION: 'Cloud Server / flutter',
+        MEMBER_ROLE: 'Lead',
+        MEMBER_YEAR: `${params.year}기` as MEMBER_DATA['MEMBER_YEAR'],
+    }
+
+    const dummyMemberList: API_MEMBER_LIST = {
+        MEMBER_CNT: 25,
+        MEMBER_LIST: [],
+    }
+
+    for (let i = 0; i < 4; i++) {
+        dummyMemberList.MEMBER_LIST.push(dummyMemberData)
+    }
+
+    const apiResult: API_RESPONSE = {
+        RESULT_CODE: 200,
+        RESULT_MSG: 'Success',
+        RESULT_DATA: dummyMemberList,
+    }
+
+    return NextResponse.json(apiResult, { status: 200 })
 }

--- a/src/app/api/member/getList/[year]/route.ts
+++ b/src/app/api/member/getList/[year]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { API_MAIN_MEMBERS, API_MEMBER_LIST, API_RESPONSE, MEMBER_DATA } from '~/src/interfaces/common'
+import { API_MAIN_MEMBERS, API_MEMBER_LIST, API_RESPONSE, MEMBER_DATA, MEMBER_PAGE_PARAMS } from '~/src/interfaces'
 
-export async function GET(request: NextRequest, { params }: { params: { year: string } }) {
+export async function GET(request: NextRequest, { params }: MEMBER_PAGE_PARAMS) {
     const dummyMemberData: MEMBER_DATA = {
         MEMBER_COMMENT: '안녕하세요, GDSC 3기 리드 유용민입니다. 잘 부탁드립니다:)',
         MEMBER_EMAIL: 'yymin1022@gmail.com',

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -9,6 +9,7 @@ export interface API_RESPONSE {
         | API_MAIN_PROJECTS
         | API_MAIN_TIMELINES
         | API_MEMBER_LIST
+        | undefined
 }
 
 export interface API_BLOG_DETAIL {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './common'
+export * from './routeParams'

--- a/src/interfaces/routeParams.ts
+++ b/src/interfaces/routeParams.ts
@@ -1,0 +1,8 @@
+type NextPageParams<Params extends Record<string, unknown>> = { params: Params }
+
+export type MEMBER_PAGE_PARAMS = NextPageParams<{ year: string }>
+
+export type EVENT_PAGE_PARAMS = NextPageParams<{ id: string }>
+
+export type BLOG_TYPE_PARAMS = NextPageParams<{ type: string }>
+export type BLOG_POST_PARAMS = NextPageParams<{ type: string; id: string }>

--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -3,12 +3,12 @@
         "strict": true,
         "baseUrl": ".",
         "paths": {
-            "~/src/*": ["/src/*"],
+            "~/src/*": ["src/*"],
             "~/utils/*": ["src/utils/*"],
             "~/styles/*": ["src/styles/*"],
             "~/hooks/*": ["src/hooks/*"],
             "~/components/*": ["src/components/*"],
-            "~/interface/*": ["src/interface/*"],
+            "~/interfaces/*": ["src/interfaces/*"],
             "~/constants/*": ["src/constants/*"]
         },
         "importHelpers": true,


### PR DESCRIPTION
## Summary
API 동작에 Dummy 데이터 Response를 구성하였습니다.

## Description
- 이전에 #41 에서 정의한 Type Interface에 맞추어, 각 API의 Response 형식에 맞추어 Dummy 데이터를 구성하였습니다.
- Blog 및 Event의 경우, 각각 10개씩의 Dummy 데이터 항목을 List로 묶어 형식에 맞게 반환합니다.
- Member List의 경우, Dummy 멤버 데이터를 25명 반환하도록 하였습니다.
- Main Project 및 Main Timeline의 경우, 형식에 맞게 데이터를 구성하여 반환합니다.

- 각 API 함수에 대한 데이터 요청 방식은 다음과 같습니다. (모두 HTTP GET을 이용합니다)
Blog 및 Event의 Detail 함수 URL 맨 뒤 ID값은 자유롭게 입력해도 정상 작동합니다.

```
Design Blog Detail : `http://localhost:3000/api/blog/getDetail/Design/1`
Development Blog Detail : `http://localhost:3000/api/blog/getDetail/Development/1`
Project Blog Detail : `http://localhost:3000/api/blog/getDetail/Project/1`
Design Blog List : `http://localhost:3000/api/blog/getList/Design`
Development Blog List : `http://localhost:3000/api/blog/getList/Development`
Project Blog List : `http://localhost:3000/api/blog/getList/Project`
Event Detail : `http://localhost:3000/api/event/getDetail/1`
Event List : `http://localhost:3000/api/event/getList`
Main 4 Projects : `http://localhost:3000/api/main/getProjects`
Main Timelines : `http://localhost:3000/api/main/getTimelines`
1기 Member List : `http://localhost:3000/api/member/getList/1`
2기 Member List : `http://localhost:3000/api/member/getList/2`
3기 Member List : `http://localhost:3000/api/member/getList/3`
```