### PR TITLE
[DEV] Mainpage의 Benefit 파트 구현

### DIFF
--- a/src/app/_components/benefits/BenefitModalSections.tsx
+++ b/src/app/_components/benefits/BenefitModalSections.tsx
@@ -10,7 +10,7 @@ export const ModalHeader = () => {
     return (
         <>
             <BenefitModal>
-                <BenefitModal.MainContent twClass="group relative col-start-1 col-end-8 row-auto overflow-hidden">
+                <BenefitModal.MainContent twClass="group relative col-start-2 col-end-7 row-auto overflow-hidden">
                     <CircleGradientHeader
                         twClass="bg-transparent w-full h-[350px]"
                         fontSize={1.4}
@@ -53,7 +53,7 @@ export const ModalFooter = () => {
                 flexDirection="row"
                 rowAlign="center"
                 colAlign="around"
-                twClass="col-start-1 gap-8 col-end-8 row-auto"
+                twClass="col-start-2 gap-8 col-end-7 row-auto"
             >
                 <BenefitCard.Header>Take the opportunity to grow.</BenefitCard.Header>
 

--- a/src/app/_components/benefits/index.tsx
+++ b/src/app/_components/benefits/index.tsx
@@ -18,11 +18,7 @@ export const Benefits = () => {
                 <ModalHeader />
 
                 <BenefitCard twClass="col-start-2 col-end-4 row-auto">
-                    <FadeIn
-                        from="translate-y-1/2 opacity-0"
-                        to="translate-y-0 opacity-100"
-                        twClass="mt-5 font-semibold"
-                    >
+                    <FadeIn from="translate-y-1/2" to="translate-y-0" twClass="mt-5 font-semibold">
                         <BenefitCard.Header>
                             Make<br></br>Networking
                         </BenefitCard.Header>
@@ -41,13 +37,9 @@ export const Benefits = () => {
 
                 <Mentor />
 
-                <BenefitCard twClass="col-start-2 col-end-5 row-auto">
-                    <FadeIn
-                        from="translate-y-1/2 opacity-0"
-                        to="translate-y-0 opacity-100"
-                        twClass="text-4xl font-semibold"
-                    >
-                        <p className="text-center">open events.</p>
+                <BenefitCard twClass="col-start-2 col-end-5 row-auto" rowAlign="center" colAlign="center">
+                    <FadeIn from="translate-y-1/2" to="translate-y-0" twClass="text-4xl font-semibold">
+                        open events.
                     </FadeIn>
                     <Image
                         src="/un-logo.png"
@@ -85,14 +77,14 @@ export const Benefits = () => {
                     />
                 </BenefitCard>
 
-                <BenefitCard twClass="col-start-4 col-end-7 row-auto text-center">
-                    <FadeIn from="translate-y-1/2 opacity-0" to="translate-y-0 opacity-100">
+                <BenefitCard twClass="col-start-4 col-end-7 row-auto text-center" rowAlign="center" colAlign="center">
+                    <FadeIn from="translate-y-1/2" to="translate-y-0">
                         <BenefitCard.Header>
-                            <div className="text-6xl font-bold">32</div>
+                            <div className="text-6xl font-bold">36</div>
                             Universities
                         </BenefitCard.Header>
                     </FadeIn>
-                    <BenefitCard.Description twClass="leading-loose justify-center items-center">
+                    <BenefitCard.Description twClass="leading-loose">
                         <BenefitCard.Description.Eng>
                             Become a better developer by interacting with 32 universities in Korea through the Google
                             Developer Student Clubs network.
@@ -106,8 +98,8 @@ export const Benefits = () => {
                 </BenefitCard>
 
                 <BenefitCard twClass="col-start-2 col-end-4 row-auto">
-                    <BenefitCard.Description>
-                        <BenefitCard.Description.Eng twClass="leading-loose mt-5">
+                    <BenefitCard.Description twClass="leading-loose mt-10">
+                        <BenefitCard.Description.Eng>
                             Join the solution challenge with us! Develop solutions to solve social problems presented by
                             the UN and win prizes!
                         </BenefitCard.Description.Eng>

--- a/src/app/_components/benefits/index.tsx
+++ b/src/app/_components/benefits/index.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import { GradientHeader } from '~/components/common'
+import { FadeIn } from '~/components/common/fadeIn'
 import { BenefitCard } from './benefitCard/BenefitCard'
 import { ModalFooter, ModalHeader } from './BenefitModalSections'
 import { Mentor } from './mentor'
@@ -17,10 +18,16 @@ export const Benefits = () => {
                 <ModalHeader />
 
                 <BenefitCard twClass="col-start-2 col-end-4 row-auto">
-                    <BenefitCard.Header>
-                        Make<br></br>Networking
-                    </BenefitCard.Header>
-                    <BenefitCard.Description>
+                    <FadeIn
+                        from="translate-y-1/2 opacity-0"
+                        to="translate-y-0 opacity-100"
+                        twClass="mt-5 font-semibold"
+                    >
+                        <BenefitCard.Header>
+                            Make<br></br>Networking
+                        </BenefitCard.Header>
+                    </FadeIn>
+                    <BenefitCard.Description twClass="leading-loose mb-5">
                         <BenefitCard.Description.Eng>
                             You can get mentoring from field experts such as GDE, a Googleer, and a senior.
                         </BenefitCard.Description.Eng>
@@ -35,17 +42,30 @@ export const Benefits = () => {
                 <Mentor />
 
                 <BenefitCard twClass="col-start-2 col-end-5 row-auto">
-                    <BenefitCard.Header>open events.</BenefitCard.Header>
+                    <FadeIn
+                        from="translate-y-1/2 opacity-0"
+                        to="translate-y-0 opacity-100"
+                        twClass="text-4xl font-semibold"
+                    >
+                        <p className="text-center">open events.</p>
+                    </FadeIn>
+                    <Image
+                        src="/un-logo.png"
+                        alt="solution challenge"
+                        className="select-none"
+                        width={250 * 1.35}
+                        height={212.39 * 1.35}
+                    />
                 </BenefitCard>
 
                 <BenefitCard twClass="col-start-5 col-end-7 row-auto">
-                    <BenefitCard.Description>
+                    <BenefitCard.Description twClass="leading-loose mt-5">
                         <BenefitCard.Description.Eng>
                             We hold various events such as Hands on Workshop, Study Group, and Hackathon. Let’s learn
                             new skills together and improve your expertise!
                         </BenefitCard.Description.Eng>
 
-                        <BenefitCard.Description.Kor>
+                        <BenefitCard.Description.Kor twClass="mt-5">
                             우리는 Hands on workshop, Study Group, Hackathon 등 다양한 이벤트를 진행합니다. 새로운
                             기술을 함께 배우고 실습하면서 전문성을 길러보세요!
                         </BenefitCard.Description.Kor>
@@ -56,38 +76,43 @@ export const Benefits = () => {
                     <BenefitCard.Header>
                         Interact<br></br>with us.
                     </BenefitCard.Header>
+                    <Image
+                        src="/un-logo.png"
+                        alt="solution challenge"
+                        className="select-none"
+                        width={250 * 1.35}
+                        height={212.39 * 1.35}
+                    />
                 </BenefitCard>
 
-                <BenefitCard twClass="col-start-4 col-end-7 row-auto">
-                    <div className="absolute justify-center">
+                <BenefitCard twClass="col-start-4 col-end-7 row-auto text-center">
+                    <FadeIn from="translate-y-1/2 opacity-0" to="translate-y-0 opacity-100">
                         <BenefitCard.Header>
-                            32
-                            <br />
+                            <div className="text-6xl font-bold">32</div>
                             Universities
                         </BenefitCard.Header>
+                    </FadeIn>
+                    <BenefitCard.Description twClass="leading-loose justify-center items-center">
+                        <BenefitCard.Description.Eng>
+                            Become a better developer by interacting with 32 universities in Korea through the Google
+                            Developer Student Clubs network.
+                        </BenefitCard.Description.Eng>
 
-                        <BenefitCard.Description>
-                            <BenefitCard.Description.Eng>
-                                Become a better developer by interacting with 32 universities in Korea through the
-                                Google Developer Student Clubs network.
-                            </BenefitCard.Description.Eng>
-
-                            <BenefitCard.Description.Kor>
-                                국내 32개 대학의 Google Developer Student Clubs 네트워크를 통해 서로 교류하며 더욱 멋진
-                                개발자로 성장해보세요!
-                            </BenefitCard.Description.Kor>
-                        </BenefitCard.Description>
-                    </div>
+                        <BenefitCard.Description.Kor>
+                            국내 32개 대학의 Google Developer Student Clubs 네트워크를 통해 서로 교류하며 더욱 멋진
+                            개발자로 성장해보세요!
+                        </BenefitCard.Description.Kor>
+                    </BenefitCard.Description>
                 </BenefitCard>
 
-                <BenefitCard twClass="col-start-2 col-end-5 row-auto">
+                <BenefitCard twClass="col-start-2 col-end-4 row-auto">
                     <BenefitCard.Description>
-                        <BenefitCard.Description.Eng>
+                        <BenefitCard.Description.Eng twClass="leading-loose mt-5">
                             Join the solution challenge with us! Develop solutions to solve social problems presented by
                             the UN and win prizes!
                         </BenefitCard.Description.Eng>
 
-                        <BenefitCard.Description.Kor>
+                        <BenefitCard.Description.Kor twClass="mt-5">
                             Solution Challenge에 GDSC 커뮤니티와 함께 참여하세요! UN이 제시한 사회적 문제를 해결하는
                             솔루션을 개발하고 입상할 기회를 잡으세요!
                         </BenefitCard.Description.Kor>
@@ -97,7 +122,7 @@ export const Benefits = () => {
                 <BenefitCard
                     colAlign="center"
                     rowAlign="center"
-                    twClass="relative col-start-5 col-end-7 row-auto gap-y-7 overflow-hidden"
+                    twClass="relative col-start-4 col-end-7 row-auto gap-y-7 overflow-hidden"
                 >
                     <div className="absolute left-1/2 top-1/3 h-48 w-48 select-none bg-white/30 blur-4xl transition-all duration-700 -translate-x-1/2 -translate-y-1/2" />
                     <Image

--- a/src/app/_components/benefits/index.tsx
+++ b/src/app/_components/benefits/index.tsx
@@ -16,83 +16,88 @@ export const Benefits = () => {
             <section className="grid grid-flow-col grid-cols-7 grid-rows-6 gap-5">
                 <ModalHeader />
 
-                <BenefitCard twClass="col-start-1 col-end-4 row-auto">
+                <BenefitCard twClass="col-start-2 col-end-4 row-auto">
                     <BenefitCard.Header>
                         Make<br></br>Networking
                     </BenefitCard.Header>
                     <BenefitCard.Description>
-                        <BenefitCard.Description.Kor>
-                            GDSC의 이벤트와 개발자 커뮤니티를 통해 GDE, 구글러, 취업 동문 등 현업 전문가를 만나고
-                            멘토링을 받을 수 있어요
-                        </BenefitCard.Description.Kor>
-
                         <BenefitCard.Description.Eng>
-                            Our events and developer community allow you to meet and mentor working professionals,
-                            including GDEs, Googlers, and working alumni.
+                            You can get mentoring from field experts such as GDE, a Googleer, and a senior.
                         </BenefitCard.Description.Eng>
+
+                        <BenefitCard.Description.Kor>
+                            GDSC에서 이루어지는 ???을 통해 GDE, 구글러, 취업 동문 등 현업 전문가를 만나고 멘토링을 받을
+                            수 있어요.
+                        </BenefitCard.Description.Kor>
                     </BenefitCard.Description>
                 </BenefitCard>
 
                 <Mentor />
 
-                <BenefitCard twClass="col-start-1 col-end-5 row-auto">
-                    <BenefitCard.Header>
-                        Make<br></br>Networking
-                    </BenefitCard.Header>
+                <BenefitCard twClass="col-start-2 col-end-5 row-auto">
+                    <BenefitCard.Header>open events.</BenefitCard.Header>
+                </BenefitCard>
 
+                <BenefitCard twClass="col-start-5 col-end-7 row-auto">
                     <BenefitCard.Description>
-                        <BenefitCard.Description.Kor>
-                            GDSC의 이벤트와 개발자 커뮤니티를 통해 GDE, 구글러, 취업 동문 등 현업 전문가를 만나고
-                            멘토링을 받을 수 있어요
-                        </BenefitCard.Description.Kor>
-
                         <BenefitCard.Description.Eng>
-                            Our events and developer community allow you to meet and mentor working professionals,
-                            including GDEs, Googlers, and working alumni.
+                            We hold various events such as Hands on Workshop, Study Group, and Hackathon. Let’s learn
+                            new skills together and improve your expertise!
                         </BenefitCard.Description.Eng>
+
+                        <BenefitCard.Description.Kor>
+                            우리는 Hands on workshop, Study Group, Hackathon 등 다양한 이벤트를 진행합니다. 새로운
+                            기술을 함께 배우고 실습하면서 전문성을 길러보세요!
+                        </BenefitCard.Description.Kor>
                     </BenefitCard.Description>
                 </BenefitCard>
 
-                <BenefitCard twClass="col-start-5 col-end-8 row-auto">
+                <BenefitCard twClass="col-start-2 col-end-4 row-auto">
                     <BenefitCard.Header>
-                        Make<br></br>Networking
+                        Interact<br></br>with us.
                     </BenefitCard.Header>
-
-                    <BenefitCard.Description>
-                        <BenefitCard.Description.Kor>
-                            GDSC의 이벤트와 개발자 커뮤니티를 통해 GDE, 구글러, 취업 동문 등 현업 전문가를 만나고
-                            멘토링을 받을 수 있어요
-                        </BenefitCard.Description.Kor>
-
-                        <BenefitCard.Description.Eng>
-                            Our events and developer community allow you to meet and mentor working professionals,
-                            including GDEs, Googlers, and working alumni.
-                        </BenefitCard.Description.Eng>
-                    </BenefitCard.Description>
                 </BenefitCard>
 
-                <BenefitCard twClass="col-start-1 col-end-4 row-auto">
-                    <BenefitCard.Header>
-                        Make<br></br>Networking
-                    </BenefitCard.Header>
+                <BenefitCard twClass="col-start-4 col-end-7 row-auto">
+                    <div className="absolute justify-center">
+                        <BenefitCard.Header>
+                            32
+                            <br />
+                            Universities
+                        </BenefitCard.Header>
 
+                        <BenefitCard.Description>
+                            <BenefitCard.Description.Eng>
+                                Become a better developer by interacting with 32 universities in Korea through the
+                                Google Developer Student Clubs network.
+                            </BenefitCard.Description.Eng>
+
+                            <BenefitCard.Description.Kor>
+                                국내 32개 대학의 Google Developer Student Clubs 네트워크를 통해 서로 교류하며 더욱 멋진
+                                개발자로 성장해보세요!
+                            </BenefitCard.Description.Kor>
+                        </BenefitCard.Description>
+                    </div>
+                </BenefitCard>
+
+                <BenefitCard twClass="col-start-2 col-end-5 row-auto">
                     <BenefitCard.Description>
-                        <BenefitCard.Description.Kor>
-                            GDSC의 이벤트와 개발자 커뮤니티를 통해 GDE, 구글러, 취업 동문 등 현업 전문가를 만나고
-                            멘토링을 받을 수 있어요
-                        </BenefitCard.Description.Kor>
-
                         <BenefitCard.Description.Eng>
-                            Our events and developer community allow you to meet and mentor working professionals,
-                            including GDEs, Googlers, and working alumni.
+                            Join the solution challenge with us! Develop solutions to solve social problems presented by
+                            the UN and win prizes!
                         </BenefitCard.Description.Eng>
+
+                        <BenefitCard.Description.Kor>
+                            Solution Challenge에 GDSC 커뮤니티와 함께 참여하세요! UN이 제시한 사회적 문제를 해결하는
+                            솔루션을 개발하고 입상할 기회를 잡으세요!
+                        </BenefitCard.Description.Kor>
                     </BenefitCard.Description>
                 </BenefitCard>
 
                 <BenefitCard
                     colAlign="center"
                     rowAlign="center"
-                    twClass="relative col-start-4 col-end-8 row-auto gap-y-7 overflow-hidden"
+                    twClass="relative col-start-5 col-end-7 row-auto gap-y-7 overflow-hidden"
                 >
                     <div className="absolute left-1/2 top-1/3 h-48 w-48 select-none bg-white/30 blur-4xl transition-all duration-700 -translate-x-1/2 -translate-y-1/2" />
                     <Image

--- a/src/app/_components/benefits/mentor/Mentor.tsx
+++ b/src/app/_components/benefits/mentor/Mentor.tsx
@@ -12,7 +12,7 @@ export const Mentor = () => {
     })
 
     return (
-        <div ref={setTiltRef} {...listeners} className="col-start-4 col-end-8 row-auto">
+        <div ref={setTiltRef} {...listeners} className="col-start-4 col-end-7 row-auto">
             <BenefitCard white colAlign="around" rowAlign="center">
                 <BenefitCard.Header>Get</BenefitCard.Header>
                 <div style={style}>


### PR DESCRIPTION
## Summary
Mainpage의 Benefit 파트 구현 완료했습니다.

## Description
- FadeIn 컴포넌트를 사용하여 인터렉션 구현 완료했습니다. 페이지를 내리면 해당 Title이 아래에서 위로 올라옵니다.
- Mainpage의 project 파트와 레이아웃 맞추기위해 benefit 틀 사이즈 수정했습니다.
 `col-start` & `col-end`를 1-8에서 2-7로 수정했습니다.

- Universities 개수가 32 -> 36으로 변경되어 데이터 수정했습니다.

- 사진은 더미 데이터를 넣었습니다. 추후 사진을 받으면 사진을 교체할 예정입니다.