### PR TITLE
[FIX] member layout

### DIFF
--- a/src/app/members/[year]/layout.tsx
+++ b/src/app/members/[year]/layout.tsx
@@ -42,13 +42,14 @@ const yearList = [
 export default function MembersLayout({ children, params: { year } }: React.PropsWithChildren<MEMBER_PAGE_PARAMS>) {
     return (
         <main className="flex h-full w-full flex-col items-start justify-between md:gap-10">
-            <div className="flex flex-row items-center justify-between gap-3 px-12 pt-4 md:gap-7 md:pb-5 md:pl-8 md:pt-10">
+            <div className="flex flex-row items-center justify-between gap-3 pl-1.5 md:gap-7 md:pb-5 md:pt-10">
                 {yearList.map(({ year: yearNumber, title }) => (
                     <YearButton key={yearNumber} year={yearNumber} isYearActive={yearNumber === year}>
                         {title}
                     </YearButton>
                 ))}
             </div>
+
             {children}
         </main>
     )

--- a/src/app/members/[year]/page.tsx
+++ b/src/app/members/[year]/page.tsx
@@ -15,12 +15,12 @@ export default async function MemberPage({ params: { year } }: MEMBER_PAGE_PARAM
     return (
         <>
             {isMemberExist ? (
-                <div className="flex flex-col py-4">
-                    <MemberHorizontalScrollView members={members.RESULT_DATA.MEMBER_LIST!} />
+                <div className="flex w-full flex-col py-4">
+                    <MemberHorizontalScrollView members={members.RESULT_DATA.MEMBER_LIST} />
                 </div>
             ) : (
                 <div className="flex flex-col py-4">
-                    <p className="font-serif text-3xl">Member {year} is not exists</p>
+                    <p className="font-eng text-3xl">Member {year} is not exists</p>
                 </div>
             )}
         </>

--- a/src/app/members/_components/MemberHorizontalScrollView.tsx
+++ b/src/app/members/_components/MemberHorizontalScrollView.tsx
@@ -24,15 +24,20 @@ interface RenderMemberByYearProps {
     members: MEMBER_DATA[]
 }
 
+const MEMBER_RENDER_INFO = {
+    MEMBER_PER_ROW_DESKTOP: 7,
+    MEMBER_PER_ROW_MOBILE: 2,
+} as const
+
 export const MemberHorizontalScrollView = ({ members }: RenderMemberByYearProps) => {
-    const dividedMembers = divideArrayIntoChunk(members, 6)
-    const dividedMembers_Mobile = divideArrayIntoChunk(members, 2)
+    const dividedMembers = divideArrayIntoChunk(members, MEMBER_RENDER_INFO.MEMBER_PER_ROW_DESKTOP)
+    const dividedMembers_Mobile = divideArrayIntoChunk(members, MEMBER_RENDER_INFO.MEMBER_PER_ROW_MOBILE)
 
     return (
-        <div>
-            <div className="hidden md:block">
+        <>
+            <div className="hidden w-full md:block">
                 {dividedMembers.map((memberChunk, rowIndex) => (
-                    <div key={rowIndex} className="relative">
+                    <div key={rowIndex} className="relative w-full">
                         <GradientBackground rowIndex={rowIndex} />
                         <div
                             className={`flex flex-row gap-8 overflow-x-auto overflow-y-hidden px-4 py-7 scrollbar-hide ${
@@ -46,6 +51,7 @@ export const MemberHorizontalScrollView = ({ members }: RenderMemberByYearProps)
                     </div>
                 ))}
             </div>
+
             <div className="block md:hidden">
                 {dividedMembers_Mobile.map((memberChunk, rowIndex) => (
                     <div key={rowIndex} className="relative flex flex-row gap-5 px-2 py-5">
@@ -55,6 +61,6 @@ export const MemberHorizontalScrollView = ({ members }: RenderMemberByYearProps)
                     </div>
                 ))}
             </div>
-        </div>
+        </>
     )
 }


### PR DESCRIPTION
## Summary
PR에 대한 간단한 요약을 작성합니다.

## Description
member page desktop에서 overflow-x가 먹히지 않는 문제를 w-full로 해결했습니다.
변경된 사항은 다음과 같습니다.

1. `MemberHorizontalScrollView` 컴포넌트의 최상단 div를 제거하고 `w-full`을 추가합니다.
2. `MemberPage` 페이지 컴포넌트에 `w-full`를 추가합니다.
     ```ts
     <div className="flex w-full flex-col py-4">
            <MemberHorizontalScrollView members={members.RESULT_DATA.MEMBER_LIST} />
     </div>
    ```

## 결과

1. 너비 `1416px`
<img width="500" alt="스크린샷 2023-09-05 오후 1 17 50" src="https://github.com/GDSC-CAU/GDSC-SPACE/assets/53421296/73f66fdb-766b-44b5-83b2-c5c562133c48">

2. 너비 `981px`
<img width="500" alt="스크린샷 2023-09-05 오후 1 18 56" src="https://github.com/GDSC-CAU/GDSC-SPACE/assets/53421296/1d2f77cb-c9e6-4c35-a62b-33dd20e2ec02">
