### PR TITLE
[FIX] Blog 및 Member 로직 이슈 해결

### DIFF
--- a/src/app/_components/sections/projects/ProjectDesktopCard.tsx
+++ b/src/app/_components/sections/projects/ProjectDesktopCard.tsx
@@ -24,7 +24,7 @@ export const ProjectCardDesktop = ({ isReverse, projectData }: ProjectCardDeskto
 
     return (
         <div className="group hidden flex-row items-center lg:flex" ref={setVisibilityRef}>
-            <Link$ href={`/blog/Development/${projectData.PROJECT_ID}`}>
+            <Link$ href={`/blog/Project/${projectData.PROJECT_ID}`}>
                 <FillImage
                     src={projectData.PROJECT_IMAGE}
                     alt={projectData.PROJECT_TITLE}

--- a/src/app/api/blog/getDetail/[type]/[id]/route.ts
+++ b/src/app/api/blog/getDetail/[type]/[id]/route.ts
@@ -16,7 +16,7 @@ export async function GET(_: NextRequest, { params: { id, type } }: BLOG_POST_PA
     const postMeta = await blogApi.getSinglePostMeta(id)
     const recordMap = await blogApi.getPostRecordMap(id)
 
-    if (recordMap.success === false || postMeta.success === false) {
+    if (!recordMap.success || !postMeta.success) {
         const apiResultError: API_RESPONSE<undefined> = {
             RESULT_CODE: 100,
             RESULT_MSG: 'Blog Not Found',

--- a/src/utils/notion/BlogPost.ts
+++ b/src/utils/notion/BlogPost.ts
@@ -138,20 +138,28 @@ export class NotionBlogPost {
     }
 
     public async getSinglePostMeta(postId: string): Promise<BlogPostApiResponse<BLOG_POST_META>> {
-        const fetchedPageData = await this.$page.retrievePage(postId)
-        const postMeta = this.getValidatedMeta(fetchedPageData)
+        try {
+            const fetchedPageData = await this.$page.retrievePage(postId)
+            const postMeta = this.getValidatedMeta(fetchedPageData)
 
-        if (postMeta === null) {
+            if (postMeta === null) {
+                return {
+                    success: false,
+                    response: null,
+                    error: `Can't fetch blog post meta data from ${postId}`,
+                }
+            }
+
+            return {
+                success: true,
+                response: postMeta,
+            }
+        } catch (e) {
             return {
                 success: false,
                 response: null,
                 error: `Can't fetch blog post meta data from ${postId}`,
             }
-        }
-
-        return {
-            success: true,
-            response: postMeta,
         }
     }
 


### PR DESCRIPTION
## Summary
Main 페이지와 Blog List 페이지의 로직 이슈를 해결하였습니다.

## Description
- Main 페이지에서 Project Card의 onClick URL이 `/blog/Development`로 이동하던 것을 `/blog/Project`로 변경하였습니다. 추가로, Firebase DB상에서의 ID값을 수정해, 정상적으로 해당 포스팅 이동하도록 하였습니다.
- Blog Detail 페이지에서, 존재하지 않는 포스팅의 ID값으로 접근하는 경우, 기존의 Next Error가 아닌 `404` 페이지가 렌더링되도록 예외처리를 추가하였습니다.
- 기존 Issue #99 에서 언급한 Member List 관련 문제점의 경우, 정상적인 것으로 다시 확인되어 수정하지 않았습니다.