### PR TITLE
[FIX] timeline card width overflow issue

### DIFF
--- a/src/app/events/_components/TimeLineCard.tsx
+++ b/src/app/events/_components/TimeLineCard.tsx
@@ -22,20 +22,24 @@ export const TimeLineCard = ({
             from="translate-x-full"
             to="translate-x-0"
             duration="700"
-            twClass="group relative inset-0 z-10 h-[13.5rem] w-full md:w-[24rem]"
+            twClass="group relative inset-0 z-10 h-[13.5rem] w-full max-w-[24rem]"
         >
-            <h1
+            <div
                 className={`${bgColor} flex h-[13.5rem] w-full select-none items-start justify-start rounded-3xl px-5 py-4 font-eng text-base text-black md:text-lg`}
             >
-                {timeLine.TIMELINE_CARD_TITLE}
-            </h1>
+                <h1 className="max-w-[15rem] truncate md:max-w-[12rem] lg:max-w-[18rem]">
+                    {timeLine.TIMELINE_CARD_TITLE}
+                </h1>
+            </div>
 
             <ul
                 className={`${borderGroupColor} absolute inset-x-0 bottom-0 flex h-[10rem] w-full flex-col items-start justify-start rounded-t-3xl rounded-bl-lg rounded-br-3xl border border-transparent bg-black p-5 transition-all duration-300 group-hover:shadow-2xl group-hover:brightness-125 group-hover:skew-x-2 group-hover:scale-105`}
             >
-                <h2 className={`${textColor} mb-10 select-none font-eng text-base md:text-lg`}>
+                <h1
+                    className={`${textColor} mb-10 select-none font-eng text-base md:max-w-[12rem] md:truncate md:text-lg lg:max-w-[18rem]`}
+                >
                     {timeLine.TIMELINE_TITLE}
-                </h2>
+                </h1>
                 <p className="select-none text-sm font-light text-white md:text-base">{timeLine.TIMELINE_DATE}</p>
                 <p className="select-none text-sm font-light text-white md:text-base">
                     {timeLine.TIMELINE_DESCRIPTION}


### PR DESCRIPTION
## Summary
특정한 screen 사이즈에서 timeline card가 잘리는 문제를 해결합니다.

<img width="979" alt="스크린샷 2023-09-08 오후 1 59 39" src="https://github.com/GDSC-CAU/GDSC-SPACE/assets/53421296/b3667e71-381f-484a-8ba7-6ed41973f657">
