### PR TITLE
[DEV] 배포시스템 대응 URL 분기처리

### DIFF
--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -4,11 +4,15 @@ export interface FetcherConstructorOption {
     baseUrl: string
 }
 export class Fetcher {
-    private baseUrl: string
+    private readonly baseUrl: string
     public static fetchPrefix = 'api' as const
 
     public constructor({ baseUrl }: FetcherConstructorOption) {
-        this.baseUrl = baseUrl
+        if (process.env.NODE_ENV && process.env.NODE_ENV === 'production' && process.env.PUB_URL) {
+            this.baseUrl = process.env.PUB_URL
+        } else {
+            this.baseUrl = baseUrl
+        }
     }
 
     public async get<APISchema>(


### PR DESCRIPTION
## Summary
API Fetch 시, Base URL을 조건에 따라 다르게 지정하도록 합니다.

## Description
- Vercel 및 Netlify의 배포시스템 상, 현재의 `localhost:3000` 주소로 요청이 불가하여 빌드가 진행되지 않는 이슈가 있습니다.
- Fetch Util을 수정하여 `NODE_ENV` 환경변수의 값과 `PUB_URL` 변수의 유무에 따라, 지정된 배포 URL 혹은 `localhost:3000`으로 Base URL이 구성되도록 하였습니다.
- Base URL은 `PUB_URL` 환경변수로 지정이 가능하며, `NODE_ENV`가 `production`이더라도 `PUB_URL`이 정의되지 않은 경우에는 `localhost:3000`으로 Fetch가 동작하도록 하였습니다.