### PR TITLE
[FIX] Prerender 관련 Fetch Issue

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -3,6 +3,8 @@ import { API_EVENT_LIST, API_RESPONSE } from '~/interfaces/Common'
 import { Fetcher } from '~/src/utils'
 import { EventCard } from './_components'
 
+export const dynamic = 'force-dynamic'
+
 const fetcher = new Fetcher({ baseUrl: 'http://localhost:3000' })
 
 export default async function EventsPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import { Footer } from '../components/common'
 import { Fetcher } from '../utils'
 import { BenefitsSection, IntroductionSection, ProjectsSection, TimeLinesSection } from './_components/sections'
 
+export const dynamic = 'force-dynamic'
+
 const fetcher = new Fetcher({
     baseUrl: 'http://localhost:3000',
 })


### PR DESCRIPTION
## Summary
Pre-render 과정에서 Fetch가 불가하여 Static Build가 이루어지지 않는 문제를 해결하였습니다.

## Description
- Main 및 Event List Page에서 `export const dynamic = 'force-dynamic'` 구문으로 `Force-Dynamic Render`를 활성화하여 Static Build 과정에서 Pre-render를 Skip 하도록 하였습니다.