### PR TITLE
[FIX] Blog 페이지 및 Footer 텍스트 오타 수정

### DIFF
--- a/src/app/blog/_components/BlogHeader.tsx
+++ b/src/app/blog/_components/BlogHeader.tsx
@@ -4,8 +4,7 @@ export const BlogHeader = ({ type }: { type: string }) => {
             <h1 className="font-eng text-5xl font-bold text-white md:text-6xl">{type} Blog</h1>
             <div className="flex flex-col gap-2">
                 <p className="text-base/normal">
-                    GDSC CAU 개발자와 디자이너의 작업 과정과
-                    <br className="md:hidden" />
+                    GDSC CAU 개발자와 디자이너의 작업 과정과 <br className="md:hidden" />
                     결과물을 공유하는 공간입니다.
                 </p>
                 <p className="text-base/normal">

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -23,7 +23,7 @@ const footerData: Readonly<
             <>
                 Designed by Sohyun Kim, Serin Seong
                 <br />
-                Developed by Yeojin Kim, Jiwoo Park, Yujin Son, Yongmin You, Junesung Jang
+                Developed by Yeojin Kim, Jiwoo Park, Yujin Son, Yongmin Yoo, Junesung Jang
             </>
         ),
     },


### PR DESCRIPTION
## Summary
일부 텍스트에 존재하는 오타를 수정하였습니다.

## Description
- Blog List 페이지의 상단 Description 텍스트에 있는 띄어쓰기 오타를 수정하였습니다.
- Footer 개발자 이름 목록의 오타를 수정하였습니다. `Yongmin You` -> `Yongmin Yoo`