### PR TITLE
[FIX] timelinecard margin

### DIFF
--- a/src/app/events/_components/TimeLineCard.tsx
+++ b/src/app/events/_components/TimeLineCard.tsx
@@ -37,7 +37,7 @@ export const TimeLineCard = ({
                 className={`${borderGroupColor} absolute inset-x-0 bottom-0 flex h-[10rem] w-full flex-col items-start justify-start rounded-t-3xl rounded-bl-lg rounded-br-3xl border border-transparent bg-black p-5 transition-all duration-300 group-hover:shadow-2xl group-hover:brightness-125 group-hover:skew-x-2 group-hover:scale-105`}
             >
                 <h1
-                    className={`${textColor} mb-10 select-none font-eng text-base md:max-w-[12rem] md:truncate md:text-lg lg:max-w-[18rem]`}
+                    className={`${textColor} mb-4 select-none font-eng text-base md:max-w-[12rem] md:truncate md:text-lg lg:max-w-[18rem]`}
                 >
                     {timeLine.TIMELINE_TITLE}
                 </h1>


### PR DESCRIPTION
## Summary
timelinecard 2줄될 때 제목 사라지는 이슈 수정했습니다

## Description
<img width="427" alt="image" src="https://github.com/GDSC-CAU/GDSC-SPACE/assets/84865066/5429229e-3b6f-480b-b7a9-26534c1d7f18">
