### PR TITLE
[FIX] 멤버 이미지 연동 에러 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,7 @@ const nextConfig = {
             'www.notion.so',
             's3.us-west-2.amazonaws.com',
             'prod-files-secure.s3.us-west-2.amazonaws.com',
+            'gdsc-cau.notion.site',
         ],
     },
 }

--- a/src/app/members/_components/MemberCard.tsx
+++ b/src/app/members/_components/MemberCard.tsx
@@ -82,8 +82,8 @@ const MemberCardBack = ({ member, isFrontViewActive }: MemberCardFrontBackViewPr
             </section>
 
             <section className="flex flex-col items-start justify-between gap-0.5">
-                {contacts.map((contactProps) => (
-                    <MemberContact {...contactProps} key={contactProps.contact}></MemberContact>
+                {contacts.map((contactProps, index) => (
+                    <MemberContact {...contactProps} key={contactProps.contact || index}></MemberContact>
                 ))}
             </section>
         </section>


### PR DESCRIPTION
## Summary
멤버 카드에 이미지가 깨지는 에러를 해결했습니다.

## Description
- 멤버 이미지가 사진과 같이 로컬 환경에서는 401에러가, 배포 환경에서는 502에러가 나타나는 문제를 해결했습니다.
![스크린샷 2025-02-18 오후 11 44 14](https://github.com/user-attachments/assets/2805168f-74c8-4d6a-aa95-d559bbb57fed)
- 멤버 사진을 노션에서 관리하는데, Firebase에 저장할때 이미지 링크를 다음과 같이 변경했습니다.
 노션에서 접근한 주소 `www.notion.so`  ->  웹에 게시된 노션에서 접근한 주소 `gdsc-cau.notion.site`
 
![스크린샷 2025-02-18 오후 11 45 13](https://github.com/user-attachments/assets/71869df8-909d-4b5f-9367-3cc7d99007fa)

- Firebase에 1기~3기의 이미지 링크를 수정했고, 4기 멤버(58명)의 정보도 업데이트 해두었습니다.
- 로컬에서는 이미지가 잘 뜨긴 하지만, 배포환경에서도 멤버 이미지가 잘 뜨는 것을 확인한 후에 나머지 깨지는 사진(대표 프로젝트 사진, 이벤트 사진)들도 수정하겠습니다.
- 머지가 되면 꼭 멤버 사진이 잘 뜨는지 확인해주시면 감사하겠습니다!!

[궁금한 점]
- 멤버 카드 뒷면에 contacts를 map(email, github, instagram)으로 불러오는 로직이 있습니다. 기존에는 이 contacts를 key값으로 두었는데, 이번 기수에는 이 세가지를 모두 빈칸으로 둔 사람들이 많아서 에러가 발생했었습니다. 그래서 값이 없는 경우에는 index로 값을 따로 두었는데, 혹시 이 방법 말고 더 좋은 방법이 있을지 궁금합니다!
<img width="812" alt="스크린샷 2025-02-18 오후 11 55 12" src="https://github.com/user-attachments/assets/8a92b894-6456-4176-a496-f6eba0b4d5ec" />