### PR TITLE
[DEV] 블로그 탭 기본값 설정

### DIFF
--- a/src/app/blog/_components/BlogArticleView.tsx
+++ b/src/app/blog/_components/BlogArticleView.tsx
@@ -44,6 +44,10 @@ const BlogArticleView = ({ BLOG_LIST, type }: BlogArticleViewProps) => {
     const filteredArticle = getFilteredArticle(BLOG_LIST, tag)
     const isDevelopmentArticle = type === 'Development'
 
+    if (filteredArticle.length === 0) {
+        return <p className="text-center text-lg">작성된 결과물이 없습니다.</p>
+    }
+
     if (isDevelopmentArticle) {
         return (
             <>


### PR DESCRIPTION
## Summary
> 블로그 탭에서 게시글이 없을 경우의 기본값을 설정합니다.

## Description
> <img width="1440" alt="스크린샷 2025-02-20 오전 12 51 48" src="https://github.com/user-attachments/assets/829226a9-0f4b-4822-bf71-2e7816e55030" />
<img width="1440" alt="스크린샷 2025-02-20 오후 11 55 43" src="https://github.com/user-attachments/assets/a1af9b4b-6dde-41ae-bf13-de01c195735b" />
> 게시글이 없는 경우 "작성된 결과물이 없습니다."라는 문구를 출력하도록 설정해 놓았습니다.
> 임시로 지정해놓은 문구이므로, 다른 문구로 수정이 필요하면 말씀해주세요.