### PR TITLE
[FIX] 멤버 카드 뒷면 contact 관련

### DIFF
--- a/src/app/members/_components/MemberCard.tsx
+++ b/src/app/members/_components/MemberCard.tsx
@@ -63,6 +63,7 @@ const MemberCardBack = ({ member, isFrontViewActive }: MemberCardFrontBackViewPr
     const contacts: MemberContactProps[] = [
         { contact: member.MEMBER_EMAIL, icon: <Email className="-ml-0.5  stroke-black scale-75" /> },
         { contact: member.MEMBER_LINK_GITHUB, icon: <LinkIcon className="-ml-0.5  stroke-black scale-75" /> },
+        { contact: member.MEMBER_LINK_BEHANCE, icon: <LinkIcon className="-ml-0.5  stroke-black scale-75" /> },
         { contact: member.MEMBER_INSTAGRAM, icon: <Instagram className="-ml-0.5 stroke-black scale-75" /> },
     ]
 

--- a/src/app/members/_components/MemberContact.tsx
+++ b/src/app/members/_components/MemberContact.tsx
@@ -3,7 +3,7 @@ export interface MemberContactProps {
     icon: React.ReactNode
 }
 export const MemberContact = ({ contact, icon }: MemberContactProps) => {
-    if (!contact) return
+    if (!contact || contact.trim() === '') return
 
     return (
         <div className="z-20 flex w-full flex-row gap-1">


### PR DESCRIPTION
## Summary
멤버 카드 뒷면 contact 관련하여 수정사항이 있었습니다.

## Description
- 개발자의 github처럼 디자이너분들에게는 behance라는 주소항목이 있습니다. 그런데 현재 멤버 카드 뒷면에 behance항목이 누락되어서 추가했습니다.
<img width="591" alt="스크린샷 2025-02-22 오후 6 26 40" src="https://github.com/user-attachments/assets/9ca73237-7d26-437d-b98f-240a57501f37" />
<img width="256" alt="스크린샷 2025-02-22 오후 6 26 54" src="https://github.com/user-attachments/assets/63735710-3a53-4f9e-a485-df4126be88c1" />

- contacts의 4가지 항목이 모두 비어있을 경우에 아무것도 렌더링 하지 않게 되어있는데, 항목이 모두 비어있는 경우에도 email 아이콘이 나타나서 조건을 추가했습니다. 
-> firebase를 확인해봤을때도 빈칸이 없었는데 왜 이메일 아이콘만 나타나는지 모르겠습니다..?
<img width="296" alt="스크린샷 2025-02-22 오후 6 28 41" src="https://github.com/user-attachments/assets/8d9f3920-866d-49de-8106-7debe252b189" />
<img width="255" alt="스크린샷 2025-02-22 오후 6 28 47" src="https://github.com/user-attachments/assets/7ae283ab-99e3-414e-bd2d-6e856d5aadd1" />

