### PR TITLE
[FIX] 블로그 아티클 시간 순 정렬

### DIFF
--- a/src/app/blog/_components/BlogArticleView.tsx
+++ b/src/app/blog/_components/BlogArticleView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Link$, Tag } from '~/src/components/common'
-import type { API_BLOG_LIST } from '~/src/interfaces'
+import type { API_BLOG_LIST, BLOG_POST_META } from '~/src/interfaces'
 import { blogRoutingData, type BlogRoutingType, type BlogTag } from '../_data/blogRouteData'
 import { BlogCategory } from './BlogCategory'
 import { BlogModalView } from './blogModal'
@@ -39,9 +39,17 @@ const getFilteredArticle = (allArticles: API_BLOG_LIST['BLOG_LIST'], tag: BlogTa
     return filteredArticle
 }
 
+const getSortedArticleByDate = (filteredArticles: API_BLOG_LIST['BLOG_LIST']) => {
+    const sortedArticle = filteredArticles.sort(
+        (a: BLOG_POST_META, b: BLOG_POST_META) => +new Date(b.BLOG_UPDATED_AT) - +new Date(a.BLOG_UPDATED_AT)
+    )
+    return sortedArticle
+}
+
 const BlogArticleView = ({ BLOG_LIST, type }: BlogArticleViewProps) => {
     const { tag, setTag } = useBlogTag()
     const filteredArticle = getFilteredArticle(BLOG_LIST, tag)
+    const sortedArticle = getSortedArticleByDate(filteredArticle)
     const isDevelopmentArticle = type === 'Development'
 
     if (isDevelopmentArticle) {
@@ -55,7 +63,7 @@ const BlogArticleView = ({ BLOG_LIST, type }: BlogArticleViewProps) => {
                     }}
                 />
                 <div className="flex w-full flex-col items-center justify-evenly gap-y-4 md:gap-y-7">
-                    {filteredArticle.map((article) => {
+                    {sortedArticle.map((article) => {
                         return (
                             <Link$
                                 href={`/blog/Development/${article.BLOG_PAGE_ID}`}


### PR DESCRIPTION
## Summary
블로그 Development 탭의 아티클 목록을 시간 순으로 정렬 처리했습니다. #154 

## Description
- [x] 아티클 목록을 최신 업데이트 날짜(BLOG_UPDATED_AT) 기준으로 정렬 처리
- [x] `getSortedArticleByDate` 함수를 생성
- [x] 필터링된 게시글 목록(`filteredArticle`)을 정렬된 상태로 `sortedArticle`에 저장 

- 노션에서 어떤 식으로 처리되는 것인지 모르겠으나 BLOG_CREATED_AT보다 BLOG_UPDATED_AT이 작성자가 아티클을 등록한 날짜에 더 가깝다고 판단하여 정렬 기준으로 선정했습니다.
- 아티클 카드에 사용하는 날짜가 BLOG_UPDATED_AT인 것을 확인했습니다. (`/blog/_components/card/DevelopCard.tsx`)

---

전후 비교
- 정렬 전

![image](https://github.com/user-attachments/assets/9f5d6bda-9f86-4309-8d33-8cd78336ee19)

- 정렬 후

![image](https://github.com/user-attachments/assets/a98a3ccb-c0b5-4eff-b80f-49d0b3d3385e)
