### PR TITLE
[FIX] Project 카드 겹침 해결

### DIFF
--- a/src/app/blog/_components/BlogArticleView.tsx
+++ b/src/app/blog/_components/BlogArticleView.tsx
@@ -72,7 +72,10 @@ const BlogArticleView = ({ BLOG_LIST, type }: BlogArticleViewProps) => {
     }
 
     return (
-        <div className="flex w-full flex-col items-center justify-evenly gap-x-2 gap-y-4 md:grid md:w-fit md:grid-cols-3 md:gap-y-8">
+        <div
+            className="grid w-fit grid-cols-1 gap-4 sm:grid-cols-2 
+        wide:grid-cols-3"
+        >
             {filteredArticle.map((article) => (
                 <DesignProjectCard type={type} article={article} key={article.BLOG_PAGE_ID} />
             ))}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,9 @@ module.exports = {
                 '4xl': '5rem',
                 '5xl': '6rem',
             },
+            screens: {
+                wide: '1180px',
+            },
         },
     },
     plugins: [require('tailwindcss-3d'), require('tailwind-scrollbar-hide')],


### PR DESCRIPTION
## Summary
화면폭이 변경될 때 Project 카드가 겹쳐지는 문제를 해결했습니다.

## Description
![문제이슈](https://github.com/user-attachments/assets/5593e166-1e41-412f-a888-1b78600d743a)
- 화면 폭을 조정할 때 위와 같이 프로젝트 카드가 겹치는 문제가 발생했습니다.
- 기존 코드는 반응형이지만 페이지의 좌우 패딩이 고려되지 않아 특정 폭 구간에서 오버플로우가 발생하였습니다.

<img width="788" alt="스크린샷 2025-02-24 오전 12 49 48" src="https://github.com/user-attachments/assets/3cac8925-1512-4883-9777-f2a1391203c8" />

- 반응형 그리드뷰로 수정하였습니다.
- tailwind의 breakpoint를 사용해 오버플로우가 발생하는 폭의 값을 기준으로 그리드가 조정되도록 하였습니다.
- 모바일뷰는 1열, 데스크탑뷰는 3열, 그 사이는 2열로 구성됩니다.
