### PR TITLE
[FIX] Members 페이지 네비게이션 변경

### DIFF
--- a/src/app/_components/navBar/NavBarDesktop.tsx
+++ b/src/app/_components/navBar/NavBarDesktop.tsx
@@ -25,7 +25,7 @@ export const NavBarDesktop = ({ iconSize = 55 }: NavBarProps) => {
             <NavButton type="link" href="/events">
                 Events
             </NavButton>
-            <NavButton type="link" href="/members/4">
+            <NavButton type="link" href="/members">
                 Members
             </NavButton>
 

--- a/src/app/_components/navBar/NavBarDesktop.tsx
+++ b/src/app/_components/navBar/NavBarDesktop.tsx
@@ -25,7 +25,7 @@ export const NavBarDesktop = ({ iconSize = 55 }: NavBarProps) => {
             <NavButton type="link" href="/events">
                 Events
             </NavButton>
-            <NavButton type="link" href="/members/3">
+            <NavButton type="link" href="/members/4">
                 Members
             </NavButton>
 

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
 
-const LATEST_YEAR = 3
+const LATEST_YEAR = 4
 
 export default function MemberRedirection() {
     redirect(`/members/${LATEST_YEAR}`)

--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -8,13 +8,7 @@ type UNIQUE_ID = string
 /**
  * Project link path
  */
-export type LinkPath =
-    | '/'
-    | `/members/${string}`
-    | BlogRoute
-    | `${BlogRoute}/${UNIQUE_ID}`
-    | '/events'
-    | `/events/${UNIQUE_ID}`
+export type LinkPath = '/' | `/members` | BlogRoute | `${BlogRoute}/${UNIQUE_ID}` | '/events' | `/events/${UNIQUE_ID}`
 
 type ExtendedUrl = UrlObject & {
     pathname: LinkPath


### PR DESCRIPTION
## Summary
- Members 페이지에서 3기로 이동하던 네비게이션을 4기로 변경했습니다.

## Description
- 원래는 LATEST_YEAR 값을 4로 업데이트하면 자동으로 반영될 줄 알았지만, 네비게이션 바(`NavBarDesktop.tsx`)에 하드코딩되어 있어서 직접 수정해야 했습니다.
- 다음 리팩토링 시 참고하실 수 있도록 기록해둡니다!

---