### PR TITLE
Fix/mem card

### DIFF
--- a/src/app/members/_components/MemberCard.tsx
+++ b/src/app/members/_components/MemberCard.tsx
@@ -43,7 +43,7 @@ const MemberCardFront = ({ member, isFrontViewActive }: MemberCardFrontBackViewP
         <MemberRoleIcon MEMBER_ROLE={member.MEMBER_ROLE} />
 
         <div
-            className="absolute bottom-0 left-0 flex h-20 w-full flex-col items-end justify-between rounded-b-xl rounded-tl-[3.5rem] rounded-tr-none bg-white p-3 md:h-28"
+            className="absolute bottom-0 left-0 flex h-20 w-full flex-col items-end justify-between rounded-b-xl rounded-tl-[3.5rem] rounded-tr-none bg-white p-3 pt-2.5 md:h-28"
             style={{
                 boxShadow: '-1px -1px 10px rgba(32, 32, 32, 0.2)',
             }}
@@ -54,7 +54,7 @@ const MemberCardFront = ({ member, isFrontViewActive }: MemberCardFrontBackViewP
             <div className="hidden md:block">
                 <Gdsc width={40} height={40} className="scale-125" />
             </div>
-            <h1 className="mt-1 font-kor text-sm text-black md:text-lg">{member.MEMBER_NAME}</h1>
+            <h1 className="mt-0.5 font-kor text-sm text-black md:text-lg">{member.MEMBER_NAME}</h1>
             <p className="mb-2 font-eng text-3xs font-light text-black md:text-xxs">{member.MEMBER_POSITION}</p>
         </div>
     </section>

--- a/src/app/members/_components/MemberCard.tsx
+++ b/src/app/members/_components/MemberCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Email, Gdsc, Instagram, Link as LinkIcon } from '~/components/icons'
 import { MEMBER_DATA } from '~/src/interfaces/Common'
+import { SVGGithub } from '~/src/styles/icons'
 import { MemberAvatar } from './MemberAvatar'
 import { MemberContact, MemberContactProps } from './MemberContact'
 import { MemberRoleIcon } from './MemberRoleIcon'
@@ -54,7 +55,7 @@ const MemberCardFront = ({ member, isFrontViewActive }: MemberCardFrontBackViewP
                 <Gdsc width={40} height={40} className="scale-125" />
             </div>
             <h1 className="mt-1 font-kor text-sm text-black md:text-lg">{member.MEMBER_NAME}</h1>
-            <p className="font-eng text-3xs font-light text-black md:text-xxs">{member.MEMBER_POSITION}</p>
+            <p className="mb-2 font-eng text-3xs font-light text-black md:text-xxs">{member.MEMBER_POSITION}</p>
         </div>
     </section>
 )
@@ -62,8 +63,11 @@ const MemberCardFront = ({ member, isFrontViewActive }: MemberCardFrontBackViewP
 const MemberCardBack = ({ member, isFrontViewActive }: MemberCardFrontBackViewProps) => {
     const contacts: MemberContactProps[] = [
         { contact: member.MEMBER_EMAIL, icon: <Email className="-ml-0.5  stroke-black scale-75" /> },
-        { contact: member.MEMBER_LINK_GITHUB, icon: <LinkIcon className="-ml-0.5  stroke-black scale-75" /> },
-        { contact: member.MEMBER_LINK_BEHANCE, icon: <Instagram className="-ml-0.5  stroke-black scale-75" /> },
+        {
+            contact: member.MEMBER_LINK_GITHUB ? member.MEMBER_LINK_GITHUB.split('/').filter(Boolean).pop() : '',
+            icon: <SVGGithub className="-ml-0.5 stroke-black scale-75" />,
+        },
+        { contact: member.MEMBER_LINK_BEHANCE, icon: <LinkIcon className="-ml-0.5  stroke-black scale-75" /> },
         { contact: member.MEMBER_INSTAGRAM, icon: <Instagram className="-ml-0.5 stroke-black scale-75" /> },
     ]
 


### PR DESCRIPTION
## Summary
1. members 페이지의 멤버 카드 뒷면에서 깃허브 url이 잘리는 문제를 해결하기 위해, 깃허브 아이콘을 추가하여 깃허브 아이디를 표시했습니다. 파이어베이스에 깃허브 url로 저장되어있어서 url을 파싱하여 id를 찾아내는 코드를 추가하였습니다.
3. members 페이지의 멤버 카드 앞면에서 position이 길어지는 경우 줄바꿈이 어색하게 되는 문제를 해결하기 위해, 전체적인 위치를 조정했습니다.

## Description
### Before - 1
<img width="756" alt="Image" src="https://github.com/user-attachments/assets/b06cb0bd-186c-40a3-ac2d-0eb52237a5e2" />

### After - 1
<img width="756" alt="Image" src="https://github.com/user-attachments/assets/647973c9-94ff-467b-a72e-12a0cf1f364d" />


### Before - 2
<img width="256" alt="Image" src="https://github.com/user-attachments/assets/74da24c4-4191-430f-9ebf-563949f36d92" />

### After - 2
<img width="256" alt="Image" src="https://github.com/user-attachments/assets/db131317-8e2a-4996-bb9b-24080deffc3e" />